### PR TITLE
Add Portuguese diarization example notebook

### DIFF
--- a/notebooks/pt_br_transcribe_diarize.ipynb
+++ b/notebooks/pt_br_transcribe_diarize.ipynb
@@ -1,0 +1,36 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "# WhisperX PT-BR Transcription and Diarization\n\nEste notebook demonstra como usar a biblioteca **whisperX** para transcrever e realizar diariza\u00e7\u00e3o de um v\u00eddeo em portugu\u00eas do Brasil."
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": "!pip install -q whisperx"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": "import whisperx\nimport torch\n\n# Defina o caminho do arquivo de v\u00eddeo ou \u00e1udio\naudio_file = 'caminho/para/video.mp4'\n\ndevice = 'cuda' if torch.cuda.is_available() else 'cpu'\ncompute_type = 'float16' if device == 'cuda' else 'float32'\n\n# 1. Transcri\u00e7\u00e3o com whisper\nmodel = whisperx.load_model('large-v2', device=device, compute_type=compute_type, language='pt')\n\naudio = whisperx.load_audio(audio_file)\nresult = model.transcribe(audio, batch_size=16)\n\n# 2. Alinhamento com wav2vec2\nmodel_a, metadata = whisperx.load_align_model(language_code='pt', device=device)\nresult = whisperx.align(result['segments'], model_a, metadata, audio, device)\n\n# 3. Diariza\u00e7\u00e3o (necessita token da HF para pyannote)\nhf_token = 'YOUR_HF_TOKEN'\ndiarize_model = whisperx.diarize.DiarizationPipeline(use_auth_token=hf_token, device=device)\ndiarize_segments = diarize_model(audio)\n\nresult = whisperx.assign_word_speakers(diarize_segments, result)\n\n# Exibir os primeiros segmentos com oradores\nfor seg in result['segments'][:5]:\n    print(f\"{seg['speaker']}: {seg['text']}\")"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "Execute todas as c\u00e9lulas acima para obter a transcri\u00e7\u00e3o com os identificadores de falantes."
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add notebook demonstrating transcription and speaker diarization for pt‑BR videos

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888dcbcc6908322a26e6ebdeab7a40b